### PR TITLE
Add stable commit ids to local.conf

### DIFF
--- a/patch/local.conf
+++ b/patch/local.conf
@@ -35,33 +35,33 @@ SYSLOG=True
 # git repos must be manually retrieved by entering /opt/stack/$SERVICE
 # and executing `git pull`
 
-#CINDER_REPO=
-#CINDER_BRANCH=
-#CINDER_COMMIT=
+CINDER_REPO=git://git.openstack.org/openstack/cinder.git
+CINDER_BRANCH=stable/pike
+CINDER_COMMIT=00f9a753ac4ed9a224d32e5614c5d57192f45a22
 
-#GLANCE_REPO=
-#GLANCE_BRANCH=
-#GLANCE_COMMIT=
+GLANCE_REPO=git://git.openstack.org/openstack/glance.git
+GLANCE_BRANCH=stable/pike
+GLANCE_COMMIT=a4562abeb13b47f8bc765f792794f6d214df96cd
 
-#HORIZON_REPO=
-#HORIZON_BRANCH=
-#HORIZON_COMMIT=
+HORIZON_REPO=git://git.openstack.org/openstack/horizon.git
+HORIZON_BRANCH=stable/pike
+HORIZON_COMMIT=0de6c6a06f87573392f4beac1b41d07401548ba5
 
-#KEYSTONE_REPO=
-#KEYSTONE_BRANCH=
-#KEYSTONE_COMMIT=
+KEYSTONE_REPO=git://git.openstack.org/openstack/keystone.git
+KEYSTONE_BRANCH=stable/pike
+KEYSTONE_COMMIT=22af1d9f35c86e9c5bca288c2996be5c19e3cd61
 
-#NEUTRON_REPO=
-#NEUTRON_BRANCH=
-#NEUTRON_COMMIT=
+NEUTRON_REPO=git://git.openstack.org/openstack/neutron.git
+NEUTRON_BRANCH=stable/pike
+NEUTRON_COMMIT=b0ca86f6b27069c6cc5726c950008c636aa9aad9
 
-#NOVA_REPO=
-#NOVA_BRANCH=
-#NOVA_COMMIT=
+NOVA_REPO=git://git.openstack.org/openstack/nova.git
+NOVA_BRANCH=stable/pike
+NOVA_COMMIT=b1ab231836f2622a4fcc38a4062740f87f058cee
 
-#SWIFT_REPO=
-#SWIFT_BRANCH=
-#SWIFT_COMMIT=
+TEMPEST_REPO=git://git.openstack.org/openstack/tempest.git
+TEMPEST_BRANCH=master
+TEMPEST_COMMIT=83b154a28369a062ab7a4c014531a86abf650133
 
 ###################
 

--- a/single_node_devstack/single_node_devstack.yml
+++ b/single_node_devstack/single_node_devstack.yml
@@ -31,7 +31,7 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
 runcmd:
   - [su, -c, "git clone -b stable/pike https://github.com/openstack-dev/devstack.git /opt/stack/devstack", stack]
-  - 'sudo svn export --force https://github.com/CCI-MOC/ORE/trunk/patch /opt/stack/devstack/'
+  - 'sudo svn export --force https://github.com/CCI-MOC/ORE/branches/stable\/moc/patch /opt/stack/devstack/'
   - 'sudo cp -r /home/centos/.ssh /opt/stack/'
   - 'sudo chown -R stack /opt/stack/.ssh'
   - 'sudo echo -e "if [[ \$- == *i* ]] && [ -d "/opt/stack/keystone" ]; then\n        . /opt/stack/devstack/openrc admin admin\nfi" >> .bashrc'


### PR DESCRIPTION
I don't have swift in `/opt/stack`, and I added tempest here because I had it. I also have:
* requirements (stable/pike, commit d3ff901be13e3c69b3952cee2388a8085ddb5d9a) 
* ceilometer (stable/pike, commit 51d4ea0a1544db06159a8d8037131428a42cc651)
* osprofiler (stable/queens, commit 2eef34430671bac137a0e16d0d87197feb726464)
* panko (stable/pike, commit f3ee4b5f230e11b213edd7a9630d9b0fcd607b8c)

Also, maybe we can pull our own osprofiler, because this one overwrites some settings related to tracing sql requests.